### PR TITLE
fixing `test_construct` test case

### DIFF
--- a/simplemath.py
+++ b/simplemath.py
@@ -18,7 +18,7 @@ class SimpleMath(object):
         :throws ValueError: if start_value is not an integer
         """
 
-        self.total = 1
+        self.total = start_value
 
     def increment(self):
         """ increment the total by 1"""


### PR DESCRIPTION
The SimpleMath object contructor was hard-coding a value instead
of setting the internal state to the contructor parameter.